### PR TITLE
Companion: SIWx documentation

### DIFF
--- a/docs/build/zano-companion/message-sign/_category_.json
+++ b/docs/build/zano-companion/message-sign/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Message Sign",
+  "link": {
+    "type": "generated-index",
+    "slug": "/build/zano-companion/message-sign"
+  }
+}

--- a/docs/build/zano-companion/message-sign/caip-namespace/_category_.json
+++ b/docs/build/zano-companion/message-sign/caip-namespace/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Specifications",
+  "position": 3
+}

--- a/docs/build/zano-companion/message-sign/caip-namespace/caip10.md
+++ b/docs/build/zano-companion/message-sign/caip-namespace/caip10.md
@@ -1,0 +1,44 @@
+---
+namespace-identifier: zano-caip10
+title: Account ID
+author: Zano Team
+status: Draft
+type: Standard
+created: 2026-06-18
+updated: 2026-06-18
+requires: ["CAIP-2", "CAIP-10"]
+---
+
+# CAIP-10
+
+*For context, see the [CAIP-10][] specification.*
+
+## Rationale
+
+This namespace, which specifies the Zano Ecosystem CAIP Account ID, is established to provide a formal implementation of the CAIP standards. At the time of its creation, its sole purpose is to support the `CAIP-122` standard implementation (provided in this folder as `caip122.md`).  
+
+## Syntax
+
+The Account ID syntax does not extend the Ethereum Account ID syntax (or the base `CAIP-10` standard) in any respect. The defined syntax is provided below:
+
+```
+account_id: chain_id + ":" + account_address
+chain_id: "zano" (See `CAIP-2` (`./caip2.md`))
+account_address: Specified in Zano Repository
+```
+
+The Zano Repository URL is available [here](https://github.com/hyle-team/zano).
+
+At the time of this document's creation, the most common `account_address` string syntax is provided below (in regex form):
+
+```
+account_address: (Zx|aZx)[1-9A-HJ-NP-Za-km-z]{95} 
+```
+
+## References
+
+- [Zano Repository](https://github.com/hyle-team/zano): Zano Repository.
+- [CAIP-2](https://standards.chainagnostic.org/CAIPs/caip-2): CAIP Blockchain ID Specification.
+- [CAIP-10](https://standards.chainagnostic.org/CAIPs/caip-10): CAIP Account ID Specification.
+
+[CAIP-10]: https://standards.chainagnostic.org/CAIPs/caip-10

--- a/docs/build/zano-companion/message-sign/caip-namespace/caip122.md
+++ b/docs/build/zano-companion/message-sign/caip-namespace/caip122.md
@@ -1,0 +1,171 @@
+---
+namespace-identifier: zano-caip122
+title: SIWx
+author: Zano Team
+status: Draft
+type: Standard
+created: 2026-06-18
+updated: 2026-06-18
+requires: ["CAIP-122", "CAIP-2", "CAIP-10"]
+---
+
+## CAIP-122
+
+This is a technical standard written at a low level of abstraction. If you only need to know how to build an integration with our service, please refer to the [Server-Side Auth Integration Guide](https://docs.zano.org/docs/build/zano-companion/message-sign/server-side-authentication-integration-guide) instead.
+
+For context, see the [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md) specification.
+
+## Rationale
+
+On Ethereum, [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) Sign-in with Ethereum already exists, which was the inspiration for CAIP-122. This document specifies the SIWX standard implementation for Zano Ecosystem.
+
+## Specification
+
+### Signing Algorithm
+
+Zano uses the Schnorr signature scheme for signing and verifying messages. The signing key is the wallet's spend key, and the corresponding public spend key (`pkey`) is used for verification. For the exact cryptographic primitives, see the [Zano Repository](https://github.com/hyle-team/zano).
+
+Messages are signed through the wallet RPC method [`sign_message`](https://docs.zano.org/docs/build/rpc-api/wallet-rpc-api/sign_message):
+
+```json
+// Request
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "method": "sign_message",
+  "params": {
+    "buff": "aGVsbG8gd29ybGQ="
+  }
+}
+```
+
+```json
+// Response
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "pkey": "9f5e...",
+    "sig": "a1b2..."
+  }
+}
+```
+
+Signatures are verified through the daemon RPC method [`validate_signature`](https://docs.zano.org/docs/build/rpc-api/daemon-rpc-api/validate_signature):
+
+```json
+// Request
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "method": "validate_signature",
+  "params": {
+    "buff": "aGVsbG8gd29ybGQ=",
+    "pkey": "9f5e...",
+    "sig": "a1b2..."
+  }
+}
+```
+
+```json
+// Response
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "status": "OK"
+  }
+}
+```
+
+For the full parameter reference, see the [Zano Docs](https://docs.zano.org/docs/build/rpc-api).
+
+### Signature Type
+
+We use the signature type `zano-schnorr` when referring to a Schnorr signature produced by a Zano wallet's spend key, as returned by the `sign_message` wallet RPC method and validated by the `validate_signature` daemon RPC method.
+
+### Signature Creation
+
+In addition to the fields REQUIRED by `CAIP-122`, this implementation elevates the following OPTIONAL fields in abstract data model to REQUIRED:
+
+- `nonce` — MUST be present. It MUST be a randomized token of at least 8 characters, used to prevent replay attacks.
+- `statement` — MUST be present.
+- `expiration-time` — MUST be present.
+
+Verifiers MUST reject any message that omits a field marked REQUIRED by this specification.
+
+The abstract data model must be converted into a string representation in an unambigious format. We use the format as defined in [`EIP-4361`](https://eips.ethereum.org/EIPS/eip-4361). Note that lines should be divided with `LF` (`'\n'`, `0x0A`) character ONLY. `CRLF` (`"\r\n"`) strings are not acceptable by this standard. String representation according to [`EIP-4361`](https://eips.ethereum.org/EIPS/eip-4361) is shown below:
+
+
+```
+${domain} wants you to sign in with your Zano account:
+${account_address(address)}
+
+${statement}
+
+URI: ${uri}
+Version: ${version}
+Chain ID: ${chain-id}
+Nonce: ${nonce}
+Expiration Time: ${expiration-time}
+```
+
+An example of a fully populated valid message:
+
+```
+example.com wants you to sign in with your Zano account:
+ZxD4n8Kp2Rj7Wm9Tv5Yx3aB6cE1fH4gJ7kL2mN5pQ8rS3tU6vW9xY2zA5bC8dE1fH4gJ7kL2mN5pQ8rS3tU6vW9xY2zA5b
+
+Sign in to Example App with your Zano account.
+
+URI: https://example.com/login
+Version: 1
+Chain ID: zano:mainnet
+Nonce: f47ac10b-58cc-4372-a567-0e02b2c3d479
+Expiration Time: 2026-06-18T12:30:00Z
+```
+
+### Signature Verification
+
+To verify a signature, the message is reconstructed into its string representation, encoded as a Base64 string, and passed to the daemon RPC method [`validate_signature`](https://docs.zano.org/docs/build/rpc-api/daemon-rpc-api/validate_signature) together with the signer's public spend key (`pkey`) and the signature (`sig`):
+
+```json
+// Request
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "method": "validate_signature",
+  "params": {
+    "buff": "aGVsbG8gd29ybGQ=",
+    "pkey": "9f5e...",
+    "sig": "a1b2..."
+  }
+}
+```
+
+```json
+// Response
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "status": "OK"
+  }
+}
+```
+
+Verifiers MUST treat the message as valid only when `status` reports success. For the full parameter reference, see the [Zano Docs](https://docs.zano.org/docs/build/rpc-api).
+
+## References
+
+[eip-4361]: https://eips.ethereum.org/EIPS/eip-4361
+[caip-10]: https://github.com/ChainAgnostic/CAIPs/blob/8fdb5bfd1bdf15c9daf8aacfbcc423533764dfe9/CAIPs/caip-10.md
+[caip-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[caip-122]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md
+
+- [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361): Sign-In with Ethereum
+- [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md): Account ID Specification
+- [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md): Blockchain ID Specification
+- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md): Sign in With X Specification
+- [Zano Documentation](https://docs.zano.org/docs/build/rpc-api): Zano RPC API Reference
+- [Zano Repository](https://github.com/hyle-team/zano): Zano Repository

--- a/docs/build/zano-companion/message-sign/caip-namespace/caip2.md
+++ b/docs/build/zano-companion/message-sign/caip-namespace/caip2.md
@@ -1,0 +1,38 @@
+---
+namespace-identifier: zano-caip2
+title: Blockchain ID
+author: Zano Team
+status: Draft
+type: Standard
+created: 2026-06-18
+updated: 2026-06-18
+requires: CAIP-2
+---
+
+# CAIP-2
+
+*For context, see the [CAIP-2][] specification.*
+
+## Rationale
+
+This namespace, which specifies the Zano Ecosystem CAIP Chain ID, is established to provide a formal implementation of the CAIP standards. At the time of its creation, its sole purpose is to support the `CAIP-122` standard implementation (provided in this folder as `caip122.md`).
+
+## Syntax
+
+At the time of this document's creation, the Zano Ecosystem does not provide the ability to create any L2 or internal chains. Therefore, only two blockchains exist within the Zano Ecosystem - Zano Mainnet and Zano Testnet. 
+
+For `mainnet` and `testnet` respectively they Chain IDs are declared as the following strings:
+
+```
+# mainnet
+zano:mainnet
+
+# testnet
+zano:testnet
+```
+
+## References
+
+- [CAIP-2](https://standards.chainagnostic.org/CAIPs/caip-2): CAIP Blockchain ID Specification.
+
+[CAIP-2]: https://standards.chainagnostic.org/CAIPs/caip-2

--- a/docs/build/zano-companion/message-sign/caip-namespace/namespace.md
+++ b/docs/build/zano-companion/message-sign/caip-namespace/namespace.md
@@ -1,0 +1,20 @@
+---
+namespace-identifier: zano
+title: Root Namespace
+author: Zano Team
+status: Draft
+type: Informational
+created: 2026-06-18
+updated: 2026-06-18
+---
+
+# Namespace for Zano Ecosystem
+
+This document serves as the formal specification of the Zano Ecosystem implementations of the CAIP standards. If you are looking for a practical integration guide, please refer to the [Server-Side Auth Integration Guide](https://docs.zano.org/docs/build/zano-companion/message-sign/server-side-authentication-integration-guide).
+
+## Rationale
+
+This namespace is established to provide a formal implementation of the CAIP standards. At the time of its creation, its sole purpose is to define the `CAIP-122` standard implementation (provided in this folder as `caip122.md`) for the Zano Ecosystem and to apply that implementation across Zano Ecosystem products.
+
+## References
+[CAIP Website](https://standards.chainagnostic.org/): Chain Agnostic Standards List.

--- a/docs/build/zano-companion/message-sign/message-sign-companion-guide.md
+++ b/docs/build/zano-companion/message-sign/message-sign-companion-guide.md
@@ -1,4 +1,8 @@
-# Message Sign
+---
+sidebar_position: 1
+---
+
+# Message Sign Companion Guide
 
 Usage of Zano Extension message sign.
 

--- a/docs/build/zano-companion/message-sign/server-side-authentication-integration-guide.md
+++ b/docs/build/zano-companion/message-sign/server-side-authentication-integration-guide.md
@@ -1,0 +1,144 @@
+---
+sidebar_position: 2
+---
+
+# Server-Side Auth Integration Guide
+
+Practical server auth integration guide via Zano Companion message sign is provided here.
+
+The flow consists of three steps, split across two server endpoints:
+
+1. **Message Generation** (`requestAuth`) — the server builds a secure, single-use
+   message bound to the user's wallet address and returns it to the client.
+2. **Message Signing** — the client signs that message with the Zano Companion
+   extension, producing a signature and the public key it was signed with.
+3. **Sign Validation** (`auth`) — the server re-validates the signature against the
+   original message, and issues a session token.
+
+Code provided in this guide is abstract and intentionally lacks of implementation of DB interaction methods, framework-specific code, ect.
+
+## Requirements
+
+Platform: `Node.js >= 18`
+
+Libraries:
+
+```text
+zano_web3: ^9.8.0
+```
+
+The integration uses two `zano_web3` submodules:
+
+- `zano_web3/shared` — `generateSecureMessageForSigning` for building the message.
+- `zano_web3/server` — `ServerWallet` for validating the signature.
+
+## Message Generation
+
+Server should have an endpoint that initializes the auth session and generates the message to be signed. In our example let it be `/request-auth`.
+
+The client sends its wallet address and the path it is authenticating from.
+The server turns these into a structured, secure message using
+`generateSecureMessageForSigning`, persists it together with an expiry, and returns it.
+
+The message is bound to the origin (`domain` / `uri`), the signing address, a single-use
+`nonce`, and a short `expirationTime` — so it cannot be replayed against another origin or
+reused after it expires.
+
+```js
+import { generateSecureMessageForSigning } from 'zano_web3/shared';
+
+async function requestAuth(req, res) {
+  const { address, path } = req.body;
+
+  const baseUrl = new URL(FRONTEND_URL);
+  const uri = new URL(path, baseUrl).toString();
+
+  const statement = `Sign this message to authenticate in ${baseUrl.host}.`;
+  const expirationTime = new Date(Date.now() + MESSAGE_TTL_MS);
+
+  const result = generateSecureMessageForSigning({
+    domain: baseUrl.host,
+    address,
+    statement,
+    uri,
+    nonce: crypto.randomUUID(), // You may generate nonce any other way
+    expirationTime,
+  });
+
+  if (!result.success) {
+    throw new Error('MESSAGE_SIGN_UNKNOWN_ERROR');
+  }
+
+  // Persist the message so it can be looked up and validated later.
+  // Storing it lets you reject signatures for messages you never issued
+  // and enforce single use by deleting the record once consumed.
+  // You may identify the auth session any way you need (e. g. auth session random ID).
+  await saveAuthMessage({ address, message: result.message, expirationTime });
+
+  return res.status(200).send({ success: true, data: result.message });
+}
+```
+
+The returned data is the exact message string the client must present to the wallet
+for signing.
+
+## Message Signing
+
+Signing happens entirely on the client with the Zano Companion extension — the server
+never sees the private key. The client passes the message returned from the
+Message Generation step to the wallet, which returns the signature and the pkey
+(the public key the signature was produced with). These are then sent back to the
+Sign Validation endpoint.
+
+For the client-side signing API, see the Zano Companion documentation:
+[Zano Companion — message signing](https://docs.zano.org/docs/build/zano-companion/message-sign/message-sign-companion-guide).
+
+## Signature Validation
+
+Server should have an endpoint that finishes auth session, validates message and its signature and issues user session token. In our example let it be `/auth`.
+
+The client submits `address`, `message`, `signature`, and `pkey`. The server validates in two stages and only then issues a session token:
+
+- Message authenticity — the submitted message must match a record the server issued and must not be expired (single-use, time-bound).
+- Signature validity — `ServerWallet.validateSecureMessageSignature` cryptographically verifies the signature against the original message and address.
+
+```js
+import { ServerWallet } from 'zano_web3/server';
+
+async function auth(req, res) {
+  const { address, message, signature, pkey } = req.body.data;
+
+  // 1. The message must have been issued by us and must not be expired.
+  const authMessage = await findAuthMessage({ address, message });
+  const isMessageValid = !!authMessage && authMessage.expiresAt.getTime() > Date.now();
+
+  if (!isMessageValid) {
+    return res.status(400).send({ success: false, data: 'Invalid auth message' });
+  }
+
+  const wallet = new ServerWallet({ daemonUrl: DAEMON_URL, walletUrl: '' });
+
+  // 2. Verify the cryptographic signature against the original message.
+  const isValidSignature = await wallet.validateSecureMessageSignature({
+    originalMessage: authMessage.message,
+    signedMessage: message,
+    signature,
+    address,
+    pkeyFromSignature: pkey,
+  });
+
+  if (!isValidSignature) {
+    return res.status(400).send({ success: false, data: 'Invalid auth data' });
+  }
+
+  const token = await issueSession({ address });
+  await deleteAuthMessage({ address, message });
+
+  return res.status(200).send({ success: true, data: token });
+}
+```
+
+Security notes:
+- Single use: delete the stored message once validated so the same signature cannot be replayed.
+- Expiry: keep the message lifetime short and always re-check expiry server-side at validation time.
+- Bind to origin: always pass real `domain`/`uri` values so a signature obtained for one app cannot be reused against another.


### PR DESCRIPTION
Brings the SIWx documentation for Companion into this repo, which is the one docs.zano.org actually builds from.

The content was merged into PRavaga/zano-docs#12 back on July 8, but that repo is upstream of this fork and nothing deploys from it, so none of these pages ever went live. The two mains have diverged (this one is 217 commits ahead), so this is a cherry-pick of the 8 files rather than a merge.

### What lands

- `message-sign.md` moves to `message-sign/message-sign-companion-guide.md` (same content, new title + frontmatter)
- new server-side auth integration guide
- new `caip-namespace/` section: CAIP-2, CAIP-10, CAIP-122, plus the namespace overview

### Two changes on top of the original PR

**Fixed two broken links in `caip122.md`.** Lines 16 and 20 had `[CAIP-122](CAIP-122)` and `[EIP-4361](EIP-4361)`, which Docusaurus resolves as relative doc links to pages that don't exist. That fails the build outright (`onBrokenLinks: throw`). Both now point at the same URLs the file's own References section uses.

**Kept `/docs/build/zano-companion/message-sign` alive.** Turning that page into a directory would have 404'd a URL that's currently in the sitemap. Added a `generated-index` link with an explicit slug in `_category_.json`, so the URL still resolves and now lists the three child pages.

### Verified

`npm ci && npm run build` passes clean. All 6 new routes render, and the old message-sign URL still resolves.
