### PR TITLE
Use/Learn content refresh: current facts, dead features removed, accurate privacy claims

### DIFF
--- a/docs/learn/emission.md
+++ b/docs/learn/emission.md
@@ -55,9 +55,9 @@ And so, a premine was seen as a necessary step to ensure that our next project, 
 
 #### Premine amount
 
-The premine consisted of 3.6M ZANO; it was set aside for ongoing project expenses, marketing, partnerships, and to pay a loan to fund initial development back in 2018.
+The premine consisted of 3.69M ZANO; it was set aside for ongoing project expenses, marketing, partnerships, and to pay a loan to fund initial development back in 2018.
 
-As of December 2024, considering what has already been spent for development, the foundation fund sits at just \~5,4% of the total ZANO supply.
+As of July 2026, considering what has already been spent for development, the foundation fund sits at about 2.9% of the total ZANO supply (roughly 440,000 ZANO).
 
 You can track the amount of the foundation fund via our [explorer](https://explorer.zano.org/) or by importing its tracking seed into your wallet:
 
@@ -75,11 +75,11 @@ Community Engagement: With the funds, we've supported various community initiati
 
 #### Decentralizing Zano's Foundation Fund
 
-Recognizing the importance of decentralization in cryptocurrency ethos, Zano is exploring ways to decentralize its development fund. One promising approach under consideration is the use of multisig wallets, where control over funds would be distributed among several keys, some of which could be held by community members or other trusted parties. This move would also tie well with our [upcoming governance voting system](https://zano.org/roadmap).
+Recognizing the importance of decentralization in cryptocurrency ethos, Zano is exploring ways to decentralize its development fund. One promising approach under consideration is the use of multisig wallets, where control over funds would be distributed among several keys, some of which could be held by community members or other trusted parties. This move also ties well with our on-chain governance voting system, live at [vote.zano.org](https://vote.zano.org).
 
 #### Future: Hybrid Sustainable Funding Model
 
-Understanding the constraints of solely depending on a premine, especially given that 78% has already been utilized, Zano is set to roll out a community crowdfunding initiative. This step is now practical due to our community's steady growth. By integrating this with the premine, we're establishing a hybrid funding model that, similar to our hybrid PoW/PoS consensus, capitalizes on the strengths of both approaches.
+Understanding the constraints of solely depending on a premine, especially given that about 88% of it has already been utilized, Zano is set to roll out a community crowdfunding initiative. This step is now practical due to our community's steady growth. By integrating this with the premine, we're establishing a hybrid funding model that, similar to our hybrid PoW/PoS consensus, capitalizes on the strengths of both approaches.
 
 #### What are the benefits of Community Crowdfunding?
 
@@ -89,4 +89,4 @@ Thanks to combining the existing premine reserves with funds sourced from the co
 
 #### Conclusion
 
-Zano's decision to implement a premine was grounded in both past experiences and the practical realities of cryptocurrency funding; it was essential for early development and growth, but with 78% spent, we are making steps towards decentralization, sustainability, and increasing community involvement. Zano is crafting a funding model that could serve as a blueprint for future crypto projects.
+Zano's decision to implement a premine was grounded in both past experiences and the practical realities of cryptocurrency funding; it was essential for early development and growth, but with most of it spent, we are making steps towards decentralization, sustainability, and increasing community involvement. Zano is crafting a funding model that could serve as a blueprint for future crypto projects.

--- a/docs/learn/frequently-asked-questions.md
+++ b/docs/learn/frequently-asked-questions.md
@@ -75,10 +75,9 @@ Zano staking is done through the desktop wallet only, since it requires running 
 
 The Zano Trade DEX (Decentralized Exchange) is a platform for trading Zano and Confidential Assets within the Zano ecosystem, offering peer-to-peer trading without custodial risks. It leverages Ionic Swaps to maintain privacy during trades.
 
-- **Decentralized:** No central authority controls the exchange.
+- **Non-custodial:** Users retain control of their funds at all times; the site never takes custody.
 - **Privacy:** Trades are conducted with confidentiality through Ionic Swaps.
-- **Non-custodial:** Users retain control of their funds.
-- **Peer-to-peer:** Direct trading between users.
+- **Peer-to-peer settlement:** Orders are matched by the Zano Trade coordinator, but every trade settles on-chain as an Ionic Swap signed by both traders. You can also arrange a swap directly from the wallet, without the site.
 
 Learn more: [Zano Trade](/docs/use/zano-trade)
 
@@ -150,7 +149,9 @@ A Ring Signature is a type of digital signature that can be performed by any mem
 
 ### What is a mixin and what is it used for?
 
-The mixin count refers to the number of signatures (apart from yours) in the ring signature that authorizes the transaction. A higher mixin value will typically provide more privacy because it will provide greater plausible deniability. It is impossible for any observer to know which is the real source of the funds.
+The mixin (or decoy) count refers to the number of outputs, apart from yours, included in the ring signature that authorizes a transaction. The decoys give you plausible deniability: an observer cannot tell which ring member is the real source of the funds.
+
+On Zano, the ring size is enforced by the protocol at 15, so every regular transaction gets the same level of privacy. It is not a setting you need to choose or tune. (The one exception is [auditable wallets](/docs/use/auditable-wallets), which deliberately spend without decoys so their history stays verifiable.)
 
 ### Can I create auditable wallets on Zano for transparency when needed?
 
@@ -186,11 +187,11 @@ But if someone accepts ZANO or its Confidential Assets, you don't have to worry 
 
 ### Was Zano pre-mined, and how was it structured?
 
-Yes, the premine consisted of 3.6M ZANO; it was set aside for ongoing project expenses, marketing, partnerships, and to pay a loan to fund initial development back in 2018.
+Yes, the premine consisted of 3.69M ZANO; it was set aside for ongoing project expenses, marketing, partnerships, and to pay a loan to fund initial development back in 2018.
 
-As of July 2025, considering what has already been spent for development, the foundation fund sits at just ~4.4% of the total ZANO supply.
+Most of it has been spent on development over the years; the current foundation-fund figure is maintained on the [Emission page](/docs/learn/emission#the-premine-and-how-zano-will-be-funded).
 
-You can track the amount of the foundation fund via our [explorer](https://explorer.zano.org/) or by importing its tracking seed into your wallet:
+You can verify the fund's balance yourself at any time by importing its public tracking seed into your wallet:
 
 `aZxat4HAWriVQ3enkGcVsrZRdMseAJswG3CSEwTqZS246VsFQ53w26eZstYsu1jWE74Atz9ajLxFnBsVTafncWNH5SMv4zHFaTS:1780c4d5dd7e97cc4a75ea8baa7977d12ef948b9a6dddc2a9a37e5e22ac7180e:1599495055`
 
@@ -204,11 +205,11 @@ A premine was seen as a necessary step to ensure that Zano has the resources nee
 
 ### Can the Zano team dump on the market, or are their funds locked?
 
-No funds are locked; however, all foundation fund transactions are public, and as of July 2025, the fund represents less than 5% of the total supply.
+No funds are locked; however, the foundation fund is an [auditable wallet](/docs/use/auditable-wallets), so its balance and every transaction are publicly verifiable, and it represents only a small share of the total supply (current figure on the [Emission page](/docs/learn/emission#the-premine-and-how-zano-will-be-funded)).
 
 ### How does Zano ensure decentralization if the devs hold some supply?
 
-Besides the fact that the foundation fund sits below 5% of the supply, Proof of Stake incentives ensure that all holders remain honest, if they were to harm the network, they would be attacking their own investment.
+Besides the fact that the foundation fund is a small share of the supply (see the [Emission page](/docs/learn/emission#the-premine-and-how-zano-will-be-funded)), Proof of Stake incentives ensure that all holders remain honest, if they were to harm the network, they would be attacking their own investment.
 
 ### Is there a public breakdown of the ZANO token distribution?
 
@@ -248,7 +249,7 @@ Unlike mixers, which obscure your transaction flow at a certain point (and you s
 
 ### How are the wrapped assets stored?
 
-In Zano wallets, both the official wallet and multicoin wallets like Edge, Cake Wallet, and Bitcoin.com.
+In Zano wallets. The official apps support all Confidential Assets, and among multicoin wallets, Edge and Bitcoin.com support them too. Cake Wallet currently supports native ZANO.
 
 ### How does unwrapping work?
 

--- a/docs/learn/specifications.md
+++ b/docs/learn/specifications.md
@@ -14,6 +14,7 @@ See also: [Emission & Tokenomics](/docs/learn/emission) for supply details, [Fea
 | Hash algorithm            | ProgPowZ                                                               |
 | Language                  | C++                                                                    |
 | Blockchain                | PoS + PoW                                                              |
+| Ring size                 | 15 (protocol-enforced)                                                 |
 | **Emission**              |                                                                        |
 | Block Time                | 1 minute                                                               |
 | Block Reward              | 1 ZANO (fixed amount)                                                  |
@@ -28,4 +29,4 @@ See also: [Emission & Tokenomics](/docs/learn/emission) for supply details, [Fea
 | Explorer                  | [https://explorer.zano.org/](https://explorer.zano.org/)               |
 | **Requirements**          |                                                                        |
 | Wallet requirements       | 2 core x64 CPU, 3 GB RAM                                               |
-| Wallet platforms          | x64 Windows 10/11, Linux or Mac OS Big Sur 11.4                        |
+| Wallet platforms          | Windows 10/11 (x64), Linux (x64), macOS, Android, iOS                  |

--- a/docs/learn/zano-features/overview.md
+++ b/docs/learn/zano-features/overview.md
@@ -12,7 +12,7 @@ A hybrid PoW/PoS consensus algorithm makes attacks on Zano infeasible. An attack
 
 ### Stability
 
-Zano's codebase has been live and tested since the Boolberry days, over a decade of production use. The network is stable, and new releases go through extensive testing before deployment.
+The Zano network has run in production since 2019, and the team's engineering lineage goes back further, through Boolberry to the original CryptoNote reference implementation. The network is stable, and new releases go through extensive testing before deployment.
 
 ### Decentralization
 
@@ -46,17 +46,9 @@ Transactions are hidden using **d/v-CLSAG Ring Signatures** (hide the sender) an
 
 **Bulletproofs+** hide the amounts in every transaction. The proofs verify that inputs and outputs balance (no coins created or destroyed) without revealing the actual numbers.
 
-### Escrow contracts
-
-Both parties lock a deposit into a contract. If either side tries to cheat, they lose their deposit. No intermediary needed. This is how Zano Trade’s P2P platform settles trades.
-
 ### Aliases
 
 Register a human-readable name like @username instead of using a long address. Aliases are on-chain and already used for the Zano Messenger, dApp authentication, and receiving payments.
-
-### Marketplace API
-
-Create, update, or deactivate on-chain offers. Once published, offers are visible to everyone on the network. Anyone can build a decentralized store on top of this.
 
 ### Ionic Swaps
 
@@ -78,21 +70,17 @@ Issue your own tokens on Zano. They get the same privacy as native ZANO: hidden 
 
 These are the products built on Zano's tech stack. Anyone can build on top of the same technologies.
 
-### Zano Trade: P2P trading
+### Zano Trade
 
-Peer-to-peer trading using escrow contracts. Both parties lock collateral, so neither can walk away. Trade any crypto or fiat without a middleman.
-
-### Zano Trade: DEX
-
-Trade ZANO and Confidential Assets with on-chain order matching and Ionic Swaps. No registration. The asset type, amount, and addresses involved are all hidden.
+The DEX. Trade ZANO and Confidential Assets: orders are matched by the Zano Trade coordinator and settle on-chain as Ionic Swaps signed by both parties. No registration, no custody. The asset type, amount, and addresses involved are all hidden.
 
 ### Zano Governance
 
-Anonymous on-chain voting for stakers. Network participants vote on protocol decisions without revealing their identity or stake.
+Anonymous on-chain voting for stakers, live at [vote.zano.org](https://vote.zano.org). Every PoS block you find during a voting window counts as one vote, so voting power follows real stake without revealing anyone's identity or balance. Proposals (ZAPs) and results are on the portal.
 
-### FUSD
+### fUSD (Freedom Dollar)
 
-A private stablecoin on Zano. Send dollars without anyone knowing how much, to whom, or when. Built as a Confidential Asset, FUSD has the same privacy guarantees as native ZANO.
+A private stablecoin on Zano, live at [freedomdollar.com](https://www.freedomdollar.com). Send dollars without anyone knowing how much, to whom, or when. Built as a Confidential Asset, fUSD has the same privacy guarantees as native ZANO.
 
 ### Zano Stats
 
@@ -122,4 +110,4 @@ An [MCP server](https://github.com/PRavaga/zano-mcp) that connects AI agents (Cl
 - **[Bandit City](https://bandit.city)** — Community hub with its own token and staking.
 - **[Alias Auction](https://auction.zano.org)** — Bid on @usernames registered on-chain.
 
-Full list at [zano.org/projects](https://zano.org/projects).
+Full list at [zano.org/projects](https://zano.org/projects). Links on this page checked July 2026.

--- a/docs/use/legacy/escrow-contracts.md
+++ b/docs/use/legacy/escrow-contracts.md
@@ -4,11 +4,17 @@ slug: /use/escrow-contracts
 
 # Escrow contracts
 
-Zano provides the framework for a secure and private transaction without the need for a trusted third party. Our Escrow system, as proposed, will require participants to make additional deposits, which they will forfeit if there is any attempt to act maliciously, or in a way that is contemptuous toward their counter party. For more information please refer to the "Escrow" section of the [whitepaper](/docs/learn/whitepaper).
+:::caution Legacy feature
+Escrow contracts are no longer available in current versions of Zano. The `Contracts` tab has been removed from the wallet, and escrow transactions are not supported under the current protocol rules (they predate the Zarcanum hard fork's transaction format). This page is kept for historical reference.
+:::
 
-### Propsal
+Zano provided a framework for secure and private transactions without the need for a trusted third party. The Escrow system required participants to make additional deposits, which they would forfeit on any attempt to act maliciously toward their counterparty. For more information please refer to the "Escrow" section of the [whitepaper](/docs/learn/whitepaper).
 
-Each escrow contract starts with the buyer proposal. Once it's sent the deposit amount will be locked for a `Time until response` period. If during the period seller accepts the terms, Escrow contract will be activated. To initiate the process navigate to wallet `Contracts` tab and choose `New Purchase`. Proposal details are the following.
+The sections below describe how the feature worked in pre-Zarcanum wallets.
+
+### Proposal
+
+Each escrow contract started with a buyer proposal. Once it was sent, the deposit amount was locked for a `Time until response` period. If the seller accepted the terms during that period, the escrow contract was activated. The process was initiated from the wallet's `Contracts` tab by choosing `New Purchase`. Proposal details were the following.
 
 - Description - title or description for contract subject
 - Seller - wallet address of merchant or seller
@@ -24,22 +30,22 @@ Each escrow contract starts with the buyer proposal. Once it's sent the deposit 
 
 ### Confirmation
 
-When the seller accepts the proposal a special multi signature transaction will be sent to the blockchain. Then after 10 confirmations a new contract will be started. The seller can now fulfil contract terms like shipping the item to the buyer.
+When the seller accepted the proposal, a special multisignature transaction was sent to the blockchain. After 10 confirmations the contract started, and the seller could fulfil the contract terms, such as shipping the item to the buyer.
 
 ![alt contract-response](/img/use/escrow-contracts/contract-response.png "contract-response")_<figcaption style={{textAlign: "center" }} >Contract response</figcaption>_
 
-The buyers contract window will get three options to continue with: `Cancel and return deposits`, `Terminate and burn deposits` and `Complete and release deposits`.
+The buyer's contract window then offered three options to continue with: `Cancel and return deposits`, `Terminate and burn deposits` and `Complete and release deposits`.
 
 ### Cancel and return deposits
 
-The buyer can send a cancellation offer to return both deposits and close the contract. The seller can accept or ignore this offer within a given response time. This option is useful when deal is mutually canceled.
+The buyer could send a cancellation offer to return both deposits and close the contract. The seller could accept or ignore this offer within a given response time. This option was useful when a deal was mutually canceled.
 
 ### Terminate and burn deposits
 
-When parties cannot find mutual agreement on any occasions one can decide to burn the deposits completely and close the contract. In that case deposits will not be returned ever.
+When the parties could not reach mutual agreement, either one could decide to burn the deposits completely and close the contract. In that case the deposits were never returned.
 
 ### Complete and release deposits
 
-If buyer is satisfied with the delivery or a provided service the contract can be closed. Releasing deposits will return both parties collaterals.
+If the buyer was satisfied with the delivery or the provided service, the contract could be closed. Releasing the deposits returned both parties' collateral.
 
 ![alt contract-confirmation](/img/use/escrow-contracts/contract-confirmation.png "contract-confirmation")_<figcaption style={{textAlign: "center" }} >Contract confirmation</figcaption>_

--- a/docs/use/overview.md
+++ b/docs/use/overview.md
@@ -11,7 +11,7 @@ This section covers how to use Zano day-to-day.
 **Features** — [Aliases](/docs/use/aliases) (@username addresses), [Auditable Wallets](/docs/use/auditable-wallets), [Wrapped Zano](/docs/use/wrapped-zano) (ERC-20 bridge).
 
 **dApps** — Most need [Zano Companion](/docs/use/companion) (browser extension) to connect your wallet:
-- [Zano Trade](/docs/use/zano-trade) — DEX and P2P trading
+- [Zano Trade](/docs/use/zano-trade) — decentralized exchange (DEX)
 - [Zano Matrix](/docs/use/zano-matrix-guide) — Encrypted messenger
 
 Having problems? See [Reporting Issues](/docs/use/reporting-issues).

--- a/docs/use/wallet-features/aliases.md
+++ b/docs/use/wallet-features/aliases.md
@@ -13,7 +13,7 @@ To reduce the possibility of phishing, we set limitations on alias registrations
 
 :::note
 
-Aliases shorter than 6 characters can only be issued by the Zano Core Team. Users can win one by participating in our monthly community events.
+Aliases shorter than 6 characters can only be issued by the Zano Core Team, which occasionally gives them away during community events. Short aliases also appear on the [Alias Auction](https://auction.zano.org).
 
 :::
 

--- a/docs/use/wallet-features/auditable-wallets.md
+++ b/docs/use/wallet-features/auditable-wallets.md
@@ -7,15 +7,15 @@ slug: /use/auditable-wallets
 
 ### What is an auditable wallet?
 
-Auditable is the type of wallet that allows 3rd party to see the balance and transaction history without permission to spend it or interact in any other way.
+Auditable is the type of wallet that allows a 3rd party to see the balance and transaction history without permission to spend it or interact in any other way. Zano itself uses this feature for the [foundation fund](/docs/learn/emission#the-premine-and-how-zano-will-be-funded), so anyone can verify its balance at any time.
 
-### How can I tell if a wallet is auditable
+### How can I tell if a wallet is auditable?
 
-It's a wallet with an address in a special format that starts with "aZx", for instance: aZxawNXAuekCXcnzutthLaPZQxAyaofb59FpzNBSCQb7iT7D1nsaxdTCvK4Xhn6nfuRpqDiNjeUNx2J9KWfTXHmDWNQ85v2bpbi
+It's a wallet with an address in a special format that starts with "aZx", for instance: aZxawtNNdH8CyS25PR7HseZwxPMdFiiDnD7w3wC8LbvNE3KbXTVsbRSTzKn1jW27fS1ySYhH77DeCYwMb6xKrevF3DzBr1cNGVv
 
 ### What is the purpose of auditable wallets?
 
-Having an auditable wallet, you can allow someone to watch your balance and transaction history without giving him/her the right to spend your funds.
+Having an auditable wallet, you can allow someone to watch your balance and transaction history without giving them the right to spend your funds. This is useful for organizations, funds, and anyone who prefers "verify" over "trust". Enabling it for one wallet doesn't affect the privacy of anyone else on the network.
 
 ### Can I get an auditable address for my existing normal wallet?
 
@@ -23,16 +23,16 @@ No. You need to create a new auditable wallet and transfer your coins into it.
 
 ### How can I create an auditable wallet?
 
-Using simplewallet CLI application:
+Using the simplewallet CLI application (see [Install a Zano CLI Wallet](/docs/use/wallets/install-zano-cli-wallet-ubuntu) if you don't have it):
 
 ```
->simplewallet.exe --generate-new-auditable-wallet my_auditable_wallet_x
-Zano_testnet wallet v1.1.7.96[3e463b0]
+>simplewallet --generate-new-auditable-wallet=my_auditable_wallet
+Zano simplewallet v2.2.1.502[76a791c]
 password: ***
-Generated new AUDITABLE wallet: aZxb9v1DFtaK6Z4bW7UUuaZcmq7MZBzz875eZ5N3vSRa2vWz9wBVE3vVKFGNH8414TTjhiwPz7PTV5ttuZP7GsdDQeWbewpmMaX
-view key: 3dd8fd870c694818194c1e7a095a51e2e65486e212baca77fce4157f39287f05
+Generated new AUDITABLE wallet: aZxawtNNdH8CyS25PR7HseZwxPMdFiiDnD7w3wC8LbvNE3KbXTVsbRSTzKn1jW27fS1ySYhH77DeCYwMb6xKrevF3DzBr1cNGVv
+view key: a2cb567ff766fa92e1d3f8f48ed3bdd23a525fd71fca7dc2b57813ac835f0b0d
 tracking seed:
-aZxb9v1DFtaK6Z4bW7UUuaZcmq7MZBzz875eZ5N3vSRa2vWz9wBVE3vVKFGNH8414TTjhiwPz7PTV5ttuZP7GsdDQeWbewpmMaX:3dd8fd870c694818194c1e7a095a51e2e65486e212baca77fce4157f39287f05:1595429852
+aZxawtNNdH8CyS25PR7HseZwxPMdFiiDnD7w3wC8LbvNE3KbXTVsbRSTzKn1jW27fS1ySYhH77DeCYwMb6xKrevF3DzBr1cNGVv:a2cb567ff766fa92e1d3f8f48ed3bdd23a525fd71fca7dc2b57813ac835f0b0d:1785345370
 **********************************************************************
 Your wallet has been generated.
 **********************************************************************
@@ -40,58 +40,48 @@ Your wallet has been generated.
 
 ### Using an auditable wallet, how can I give someone the ability to track my balance and transaction history?
 
-You should obtain a **tracking seed** for your auditable wallet and give it to someone you'd like to be able to track your wallet. At the moment, it can only be done by using `tracking_seed` command in simplewallet:
+Give them the **tracking seed** for your auditable wallet. It is shown when the wallet is generated, and you can display it again at any time with the `tracking_seed` command in simplewallet:
 
 ```
->simplewallet.exe --wallet-file my_auditable_wallet_x
-Zano_testnet wallet v1.1.7.96[3e463b0]
+>simplewallet --wallet-file my_auditable_wallet
+Zano simplewallet v2.2.1.502[76a791c]
 password: ***
-Opened auditable wallet: aZxb9v1DFtaK6Z4bW7UUuaZcmq7MZBzz875eZ5N3vSRa2vWz9wBVE3vVKFGNH8414TTjhiwPz7PTV5ttuZP7GsdDQeWbewpmMaX
-Starting refresh...
-Refresh done, blocks received: 0
-balance: 0.000000000000, unlocked balance: 0.000000000000
-**********************************************************************
-Use "help" command to see the list of available commands.
-**********************************************************************
-[Zano wallet aZxb9v]: tracking_seed
+Opened auditable wallet: aZxawtNNdH8CyS25PR7HseZwxPMdFiiDnD7w3wC8LbvNE3KbXTVsbRSTzKn1jW27fS1ySYhH77DeCYwMb6xKrevF3DzBr1cNGVv
+[Zano wallet aZxawt]: tracking_seed
 Auditable watch-only tracking seed for this wallet is:
-aZxb9v1DFtaK6Z4bW7UUuaZcmq7MZBzz875eZ5N3vSRa2vWz9wBVE3vVKFGNH8414TTjhiwPz7PTV5ttuZP7GsdDQeWbewpmMaX:3dd8fd870c694818194c1e7a095a51e2e65486e212baca77fce4157f39287f05:1595429852
+aZxawtNNdH8CyS25PR7HseZwxPMdFiiDnD7w3wC8LbvNE3KbXTVsbRSTzKn1jW27fS1ySYhH77DeCYwMb6xKrevF3DzBr1cNGVv:a2cb567ff766fa92e1d3f8f48ed3bdd23a525fd71fca7dc2b57813ac835f0b0d:1785345370
 Anyone having this tracking seed is able to watch your balance and transaction history, but unable to spend coins.
 ```
 
-Tracking seed technically is an auditable address, secret view key and a creation timestamp combined with a colon: aZxawNXAuekCXcnzutthLaPZQxAyaofb59FpzNBSCQb7iT7D1nsaxdTCvK4Xhn6nfuRpqDiNjeUNx2J9KWfTXHmDWNQ85v2bpbi:1be5866b6fda704c0c4a08f9c79c774911fda72dcd8cc8c7ca31bc1a6fda4d0b:1593998615
+Technically, a tracking seed is the auditable address, the secret view key, and a creation timestamp joined with colons.
 
 ### I got a tracking seed. How can I track the wallet it is bound to?
 
-You need to restore a wallet using the tracking key the same way you restore a regular wallet using a seed. It could be done in simplewallet:
+Restore a wallet from the tracking seed the same way you restore a regular wallet from a seed phrase. In simplewallet:
 
 ```
->simplewallet.exe --restore-wallet=wallet-name
-Zano_testnet wallet v1.1.7.96[3e463b0]
+>simplewallet --restore-wallet=tracking-wallet
+Zano simplewallet v2.2.1.502[76a791c]
 password: ***
 please, enter wallet seed phrase or an auditable wallet's tracking seed: ***
-Tracking wallet restored: aZxb9v1DFtaK6Z4bW7UUuaZcmq7MZBzz875eZ5N3vSRa2vWz9wBVE3vVKFGNH8414TTjhiwPz7PTV5ttuZP7GsdDQeWbewpmMaX
+Tracking wallet restored: aZxawtNNdH8CyS25PR7HseZwxPMdFiiDnD7w3wC8LbvNE3KbXTVsbRSTzKn1jW27fS1ySYhH77DeCYwMb6xKrevF3DzBr1cNGVv
 **********************************************************************
 Your wallet has been restored.
 To start synchronizing with the daemon use "refresh" command.
-Use "help" command to see the list of available commands.
-Always use "exit" command when closing simplewallet to save
-current session's state. Otherwise, you will possibly need to synchronize
-your wallet again. Your wallet keys is NOT under risk anyway.
 **********************************************************************
 ```
 
-Or in GUI wallet:
+Or in the GUI wallet, choose `Restore from backup` and paste the tracking seed instead of a seed phrase:
 
 ![alt auditable-wallets-gui-wallet](/img/use/wallet-features/auditablewallet.png "auditable-wallets-gui-wallet")
 
 ### Are there any restrictions on using auditable wallets?
 
-Only one: you cannot use mixins when you send coins from an auditable wallet.
+Only one: transactions sent from an auditable wallet don't use decoys (ring size 0), so the audit trail stays fully verifiable. Regular Zano wallets use the protocol-enforced ring size of 15. This is a property of the auditable wallet only; it doesn't affect anyone else's privacy.
 
 ### Can I use integrated addresses with the auditable feature?
 
-Yes. An integrated address for an auditable wallet can be generated as usual. Such addresses will have "aiZ" prefix.
+Yes. An integrated address for an auditable wallet can be generated as usual. Such addresses have the "aiZX" prefix.
 
 ### Can I mine PoS with my auditable wallet?
 

--- a/docs/use/wallet-features/socks5-proxy-relay.md
+++ b/docs/use/wallet-features/socks5-proxy-relay.md
@@ -53,13 +53,13 @@ simplewallet --wallet-file <your_wallet> \
 
 ### Relay transactions through Tor (HTTP)
 
-Same thing, but over plain HTTP (port 11121):
+Same thing, but over plain HTTP to a node that exposes its RPC port (default 11211). Note that the public `node.zano.org` serves RPC over HTTPS on port 443 only, so use this form with your own remote node:
 
 ```
 simplewallet --wallet-file <your_wallet> \
   --daemon-address http://127.0.0.1:11211 \
   --enable-tx-socks5-relay-proxy=127.0.0.1:9150 \
-  --tx-relay-url=http://node.zano.org:11121
+  --tx-relay-url=http://<your_remote_node>:11211
 ```
 
 ### Relay both transactions and PoS blocks
@@ -83,5 +83,5 @@ For testnet, just point to a testnet node (default RPC port is 12111):
 simplewallet --wallet-file <your_wallet> \
   --daemon-address http://127.0.0.1:12111 \
   --enable-tx-socks5-relay-proxy=127.0.0.1:9150 \
-  --tx-relay-url=<testnet_node_address>:11311
+  --tx-relay-url=http://<testnet_node_address>:12111
 ```

--- a/docs/use/wallets/cli/using-zano-cli-wallet-ubuntu.md
+++ b/docs/use/wallets/cli/using-zano-cli-wallet-ubuntu.md
@@ -57,7 +57,7 @@ The `transfer` command takes a mixin count, destination address, and amount:
 transfer <mixin_count> <address> <amount>
 ```
 
-- **mixin_count**: the number of decoy outputs mixed with yours for privacy. Use **15** for standard wallets, **0** for auditable wallets.
+- **mixin_count**: the number of decoy outputs mixed with yours. Use **15** for standard wallets (this is the protocol-enforced ring size, so it is not a privacy dial you can tune) and **0** for auditable wallets, which always spend without decoys.
 - **address**: the recipient's Zano address (starts with `Zx` or `aZx`)
 - **amount**: the amount of ZANO to send
 

--- a/docs/use/wallets/gui-wallet.md
+++ b/docs/use/wallets/gui-wallet.md
@@ -33,7 +33,7 @@ Zano is available for mobile (Android/iOS) and desktop (Windows, Linux and MacOS
 
 :::info
 
-Some antivirus programs do not recognize wallet software and automatically flag it as a virus, resulting in a false positive. In that case, you will need to add zano.exe to your exclusion list.
+Some antivirus programs do not recognize wallet software and automatically flag it as a virus, resulting in a false positive. Before adding any exclusion, make sure you downloaded the wallet from [zano.org/wallets](https://zano.org/wallets) or the official [GitHub releases](https://github.com/hyle-team/zano/releases), and that its SHA256 checksum matches the one published in the release notes. Only then add zano.exe to your antivirus exclusion list.
 
 :::
 
@@ -71,15 +71,15 @@ The wallet has been created. You can copy your wallet address to receive ZANO or
 
 Each Zano wallet can be identified by a custom name assigned upon creation. This name can be edited in `Wallet options` the section at any time. Information about the wallet file location and its seed phrase is available here. Note that you can copy the seed phrase by clicking the right mouse button over it and choosing `COPY` from the context menu.
 
-You can remove a wallet from the Zano app by clicking `Close wallet` in the same section. Note that the wallet file will remain unaffected, and you can import it again anytime if necessary.
+You can remove a wallet from the Zano app by clicking `Close` in the same section. Note that the wallet file will remain unaffected, and you can import it again anytime if necessary.
 
 ### Changing wallet password
 
-In case you want to change the wallet file password, you need to use `Restore from backup`. Do **not** delete your existing wallet file until the restored wallet is verified and working:
+The GUI has no built-in option to change a wallet file's password (the password field in Settings changes the app's master password, not the wallet file's). To change the wallet file password, you need to use `Restore from backup`. Do **not** delete your existing wallet file until the restored wallet is verified and working:
 
 1. Make sure you have the seed phrase saved (and the seed passphrase, if you set one)
 2. Copy the current wallet file to a separate location as a backup
-3. Click `Close wallet` from wallet `Details`
+3. Click `Close` from the wallet's `Details` section
 4. Click `+Add` from `Wallets` menu and choose `Restore from backup`
 5. Enter new wallet info with the new password
 6. Recover and enter the previously stored seed phrase

--- a/docs/use/zano-matrix-guide.mdx
+++ b/docs/use/zano-matrix-guide.mdx
@@ -12,7 +12,7 @@ Matrix is a communication protocol for decentralized messaging, voice, and video
 
 ## What is Zano Matrix?
 
-With an increase in compromised communication platforms like Telegram and WhatsApp, we decided to integrate Zano with Matrix to have our own decentralized messenger server that authenticates via Zano aliases! Zano Matrix is a secure open-source messenger that authenticates via aliases in the Zano decentralized network. In addition, our private and encrypted server runs on our own hardware, ensuring that all messages are fully encrypted. By registering with your Zano alias, you can claim a unique username, ensuring your messages are safe and your online identity is verified while maintaining your privacy!
+With an increase in compromised communication platforms like Telegram and WhatsApp, we decided to integrate Zano with Matrix to have our own decentralized messenger server that authenticates via Zano aliases! Zano Matrix is a secure open-source messenger that authenticates via aliases in the Zano decentralized network. The homeserver runs on Zano's own hardware, and conversations support end-to-end encryption, so encrypted messages are unreadable to the server. By registering with your Zano alias, you can claim a unique username: your online identity is verified while your privacy is maintained.
 
 ## Why use Zano Matrix?
 
@@ -69,7 +69,7 @@ Simply click the Matrix connection icon to be forwarded to a one-on-one chat usi
 
 ##### **Can someone read my messages?**
 
-No, Matrix is a secure protocol designed to protect your privacy.
+Messages in end-to-end encrypted chats can only be read by the participants, not by the server or its operators. Standard Matrix clients like Element enable end-to-end encryption by default for private conversations; you can confirm it is on for a room via the shield icon in the room settings. Room metadata (who talks to whom, and when) is visible to the homeserver, as with any Matrix setup.
 
 ##### **Does the server or Element Messenger have access to the keys of your Zano wallet?**
 

--- a/docs/use/zano-trade.md
+++ b/docs/use/zano-trade.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Zano Trade
 
-A decentralized exchange to trade native Zano and all the Confidential Assets launched on Zano’s ecosystem. Zano Trade requires no user registration and uses an on-chain order matching system to facilitate [Ionic Swaps](/docs/learn/frequently-asked-questions#what-are-ionic-swaps) between native Zano and the Confidential Assets. It is impossible to see what asset type, amount, or address was involved in the transaction.
+A decentralized exchange to trade native Zano and all the Confidential Assets launched on Zano’s ecosystem, with no user registration. You post orders on the site, the Zano Trade coordinator matches compatible buy and sell orders, and each trade settles on-chain as an [Ionic Swap](/docs/learn/frequently-asked-questions#what-are-ionic-swaps) signed by both parties from their own wallets. The site never takes custody of funds, and outside observers cannot see what asset type, amount, or address was involved in a settled trade.
 
 ## How to use
 
@@ -135,7 +135,7 @@ When users publish their orders to Zano Trade, our DEX coordinator combines sell
 
 ### Is Zano Trade decentralized?
 
-Zano trade is simply a forum for users to find each other's orders, at no point does it hold any custody of funds.&#x20;
+Zano Trade is a non-custodial matching venue: the site helps buyers and sellers find each other and coordinates the swap transaction, but at no point does it hold funds. Settlement always happens on-chain, signed by the two traders.
 
 You can even do trades without the site by simply using the "Swap" function available in the official Zano wallets, in a fully self-hosted manner.
 


### PR DESCRIPTION
Second pass over the Use and Learn tabs, following up on #29. Everything here was checked against the v2.2.1.502 source, the live network, or the vendor sites before changing the text.

- Emission/FAQ: current foundation fund figure (~2.9% of supply, roughly 440k ZANO), premine spent ~88%, fund number now lives only on the Emission page, governance points to vote.zano.org
- Features overview: removed escrow and Marketplace API sections (dead since Zarcanum / disabled by default), merged the two Zano Trade blurbs into one accurate description, fUSD naming and link, lineage wording untangled
- FAQ: ring size 15 is protocol enforced, not a privacy dial; DEX answer no longer claims there is no central coordinator; wrapped asset wallet support corrected (Cake is native ZANO only)
- Auditable wallets: transcripts regenerated on 2.2.1.502, foundation fund as the real world example, aiZX prefix fix
- SOCKS5 guide: fixed broken relay examples (wrong ports; node.zano.org serves RPC on HTTPS 443 only)
- GUI wallet: antivirus note now requires download and checksum verification first, documented that the GUI has no wallet file password change, button label fixes
- Matrix guide: accurate E2EE wording (client side, room metadata visible to the homeserver)
- Escrow legacy page: marked unavailable under current protocol rules and rewritten as historical
- Specifications: ring size row added, platform list updated

Build green with onBrokenLinks: throw.