### PR TITLE
Text consistency sweep: headings, product names, terminology

### DIFF
--- a/docs/build/confidential-assets/ionic-swaps.md
+++ b/docs/build/confidential-assets/ionic-swaps.md
@@ -188,4 +188,4 @@ Refresh done, blocks received: 42776
 
 ```
 
-From Finalizer's wallet perspective same transaction c08522c94355524cc8a1fa1514419814e99989ba503382256cbffc39a733a186 sends 10 Zano and receives 2 CT tokens.
+From Finalizer's wallet perspective same transaction c08522c94355524cc8a1fa1514419814e99989ba503382256cbffc39a733a186 sends 10 ZANO and receives 2 CT tokens.

--- a/docs/build/confidential-assets/methods/_category_.json
+++ b/docs/build/confidential-assets/methods/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "Commands",
+  "label": "Asset Methods",
   "position": 2
 }

--- a/docs/build/confidential-assets/overview.md
+++ b/docs/build/confidential-assets/overview.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Overview
+# Confidential Assets Overview
 
 Confidential Assets are privacy tokens with all the features of native Zano coin
 

--- a/docs/build/deeplinks.md
+++ b/docs/build/deeplinks.md
@@ -1,5 +1,5 @@
 ---
-slug: /use/deeplinks
+slug: /build/deeplinks
 ---
 
 # Deeplinks

--- a/docs/build/exchange-guidelines/integrated-addresses-for-exchanges.md
+++ b/docs/build/exchange-guidelines/integrated-addresses-for-exchanges.md
@@ -1,7 +1,5 @@
 # Integrated addresses for exchanges
 
-### Starting the daemon and the wallet application as RPC server
-
 Unlike Bitcoin, CryptoNote family coins have different, more effective approach on how to handle user deposits.
 
 An exchange generates only one address for receiving coins and all users send coins to that address. To distinguish different deposits from different users the exchange generates random identifier (called **payment ID**) for each one and a user attaches this payment ID to his transaction while sending. Upon receiving, the exchange can extract payment ID and thus identify the user.<br/>

--- a/docs/build/exchange-guidelines/jwt-guide.md
+++ b/docs/build/exchange-guidelines/jwt-guide.md
@@ -17,7 +17,7 @@ header.payload.signature
 
 ## Use Case in Our Project
 
-We use JWT authentication to secure HTTP requests to our local JSON-RPC API betweedn Zano desktop App and Zano Extension (Zano Companion). Each request includes a signed JWT in the `Zano-Access-Token` header, which is verified by the server.
+We use JWT authentication to secure HTTP requests to our local JSON-RPC API between the Zano desktop wallet and Zano Companion (browser extension). Each request includes a signed JWT in the `Zano-Access-Token` header, which is verified by the server.
 You can enable JWT authentification in simplewallet as well by adding `--jwt-secret=hsjejkcdskndspo230XASIijksk123i9x5` when simplewallet run in server mode (with --rpc-bind-port=PORT_NUM option).
 
 ---

--- a/docs/build/libraries/overview.md
+++ b/docs/build/libraries/overview.md
@@ -4,7 +4,7 @@
 
 Zano Web3 TS is a TypeScript library designed to facilitate interaction with the Zano Companion extension within web browsers. It enables connection to user extensions, handles authentication, and manages wallet credentials, plus it includes a server component for RPC interactions with the Zano wallet and daemon.
 
-Github: https://github.com/hyle-team/zano_web3
+GitHub: https://github.com/hyle-team/zano_web3
 
 Package: https://www.npmjs.com/package/zano_web3
 
@@ -12,22 +12,22 @@ Package: https://www.npmjs.com/package/zano_web3
 
 This C++ library provides tools for integrating Zano's wallet into native iOS and Android applications, offering a robust solution for mobile app developers working with Zano's technology. All API implemented as a plain text calls that works with JSON format, which make this library a perfect framework agnostic tool for supporting Zano.
 
-Github: https://github.com/hyle-team/zano_native_lib
+GitHub: https://github.com/hyle-team/zano_native_lib
 
 ## Flutter/Android Zano Wallet Plugin (Dart)
 
 This Dart library is tailored for integrating Zano Wallet functionalities into mobile and web applications using the Flutter framework or native Android development with Dart, making it ideal for mobile developers.
 
-Github: https://github.com/hyle-team/zano_plugin
+GitHub: https://github.com/hyle-team/zano_plugin
 
 ## SWIFT package manager plugin for Native Wallet Library for IOS/Android (C++)
 
 A dedicated iOS library that allows for the integration of Zano's functionalities specifically within iOS applications, ensuring smooth implementation of Zano features on Apple devices.
 
-Github: https://github.com/hyle-team/zano_native_lib_package_ios
+GitHub: https://github.com/hyle-team/zano_native_lib_package_ios
 
 ## Zano Node Utils (JavaScript)
 
 This utility library supports various backend operations used by mining pools
 
-Github: https://github.com/hyle-team/zano-node-util
+GitHub: https://github.com/hyle-team/zano-node-util

--- a/docs/build/overview.md
+++ b/docs/build/overview.md
@@ -14,9 +14,9 @@ Start with the RPC API [Overview](rpc-api/overview.md) and [How to call the API]
 
 If launching your own project centered around private transactions is your goal, our [Confidential Assets](confidential-assets/overview.md) section provides detailed methods to give your initiative a solid foundation.
 
-## Exchange Listing Guidelines
+## Exchange Integration Guidelines
 
-If you're looking to list your project or Zano assets on exchanges, it's crucial to follow specific guidelines to ensure compliance and success in your listings. We provide a [detailed set of guidelines](https://docs.zano.org/docs/build/exchange-guidelines/multi-assets-custody-guide) that cover everything from technical requirements to compliance with financial regulations.
+Running a Zano deposit or withdrawal service? The [exchange integration guide](exchange-guidelines/multi-assets-custody-guide.md) covers wallet custody, payment IDs and integrated addresses, production node setup, and offline signing.
 
 ## Tools and Resources
 

--- a/docs/build/rpc-api/_category_.json
+++ b/docs/build/rpc-api/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "API Reference",
+  "label": "RPC API",
   "position": 3
 }

--- a/docs/build/rpc-api/overview.md
+++ b/docs/build/rpc-api/overview.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Overview
+# RPC API Overview
 
 Welcome to the Zano API documentation! As a digital currency enthusiast, developer, or end user, we know how important it is for you to have a clear, comprehensive guide to our API. That's why we've designed our documentation to be as accessible and easy to understand as possible.
 
@@ -78,9 +78,10 @@ In order to interact with the Marketplace API, you must include the following fl
 ./simplewallet --wallet-file example.wallet --password password --rpc-bind-ip 127.0.0.1 --rpc-bind-port 11212 --daemon-address 127.0.0.1:11211
 ```
 
-### Daemon flags
+### Wallet flags
 
 - wallet-file - name of wallet file to use
 - password - wallets password
 - rpc-bind-port - TCP port for wallet RPC server
-- rpc-bind-ip - IP and PORT of the daemon
+- rpc-bind-ip - IP address to bind the wallet RPC server to
+- daemon-address - IP and port of the daemon to connect to

--- a/docs/build/zano-trade-api/_category_.json
+++ b/docs/build/zano-trade-api/_category_.json
@@ -1,3 +1,3 @@
 {
-  "label": "Zano trade API"
+  "label": "Zano Trade API"
 }

--- a/docs/build/zano-trade-api/confirm-transaction/_category_.json
+++ b/docs/build/zano-trade-api/confirm-transaction/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "Сonfirm transaction",
+  "label": "Confirm transaction",
   "position": 7
 }

--- a/docs/learn/ecosystem.md
+++ b/docs/learn/ecosystem.md
@@ -21,7 +21,7 @@ Anonymous on-chain voting for stakers, live at [vote.zano.org](https://vote.zano
 
 A private stablecoin on Zano, live at [freedomdollar.com](https://www.freedomdollar.com). Send dollars without anyone knowing how much, to whom, or when. Built as a Confidential Asset, fUSD has the same privacy guarantees as native ZANO.
 
-### Zano Stats
+### ZanoStats
 
 Network statistics dashboard with staking data, analytics, and market insights. Available at [zanostats.com](https://zanostats.com). (The blockchain explorer itself is at [explorer.zano.org](https://explorer.zano.org).)
 
@@ -43,8 +43,8 @@ An [MCP server](https://github.com/PRavaga/zano-mcp) that connects AI agents (Cl
 
 - **[Wrapped Zano](https://wrapped.zano.org)**: WZANO, an ERC-20 token on Ethereum. Exchangeable 1:1 for native ZANO.
 - **[Obscura](https://obscura.art)**: private NFT minting and management.
-- **[Zano Messenger](/docs/use/zano-matrix-guide)**: private messaging built on Matrix with end-to-end encryption support, linked to your Zano alias.
-- **[Bridgeless](https://bridgeless.com)**: non-custodial bridge between public and privacy blockchains. Uses Zano gateway addresses with ETH-compatible signatures for cross-chain asset commands.
+- **[Zano Matrix](/docs/use/zano-matrix-guide)**: private messaging built on Matrix with end-to-end encryption support, linked to your Zano alias.
+- **[Confidential Layer](https://confidentiallayer.com)**: non-custodial bridge between public blockchains and Zano, built on the [Bridgeless](https://bridgeless.com) L1. Uses Zano gateway addresses with ETH-compatible signatures for cross-chain asset commands.
 - **[Zano Bay](https://zanobay.com)**: private marketplace for buying and selling goods.
 - **[Bandit City](https://bandit.city)**: community hub with its own token and staking.
 - **[Alias Auction](https://auction.zano.org)**: bid on @usernames registered on-chain.

--- a/docs/learn/emission.md
+++ b/docs/learn/emission.md
@@ -35,9 +35,9 @@ sidebar_position: 4
 
 Zano has a hybrid PoW/PoS consensus algorithm to secure the network and therefore emission is generated from two distinct sources:
 
-Proof of Work (PoW) mining, which creates new ZANO coins to reward miners for completing the calculations and therefore contributing to the network.
+Proof-of-Work (PoW) mining, which creates new ZANO coins to reward miners for completing the calculations and therefore contributing to the network.
 
-Proof of Stake (PoS) staking, which also creates new ZANO coins to reward users who stake their funds and therefore also contributing to the network's security.
+Proof-of-Stake (PoS) staking, which also creates new ZANO coins to reward users who stake their funds and therefore also contributing to the network's security.
 
 100% of the block reward goes to the miner or staker who found the block. The key emission parameters are in the table above.
 
@@ -83,7 +83,7 @@ You can track the amount of the foundation fund via our [explorer](https://explo
 
 The choice to implement a premine has enabled us to maintain a full-time, dedicated team on Zano from the start, even through the most brutal crypto winters. This strategic decision has allowed us to excel across multiple fronts:
 
-Development: We've continuously enhanced our blockchain technology with key upgrades like the Zarcanum hard fork, which introduced the world's first Private Proof of Stake model and support for issuing Confidential Assets.
+Development: We've continuously enhanced our blockchain technology with key upgrades like the Zarcanum hard fork, which introduced the world's first Private Proof-of-Stake model and support for issuing Confidential Assets.
 
 Marketing: The premine has funded efforts to boost our visibility, including securing listings on centralized exchanges and creating educational content.
 

--- a/docs/learn/frequently-asked-questions.md
+++ b/docs/learn/frequently-asked-questions.md
@@ -57,6 +57,10 @@ On the consensus side, Zano runs a hybrid PoW/PoS model instead of Monero's pure
 
 See all compatible wallets: [zano.org/wallets](https://zano.org/wallets)
 
+### What is a seed phrase?
+
+To access the wallet in the event of a loss, you need something called a mnemonic recovery phrase or seed. This group of words that you received while creating your wallet is designed to add an extra layer of security. With these phrases you can easily restore lost wallets if you don't have the passkey. See the [seed phrase guide](/docs/use/seed-phrase) for how to store it safely.
+
 ### Where can I trade Zano?
 
 See all places where you can trade Zano: [zano.org/exchanges](https://zano.org/exchanges)
@@ -107,7 +111,7 @@ Zano dApps can use alias-based authentication, as [Zano Matrix](/docs/use/zano-m
 
 ### What is Zarcanum?
 
-Zarcanum is the world's first Proof of Stake scheme that enhances traditional PoS with untraceability and hidden amounts, revolutionizing blockchain consensus. Thanks to this innovative approach, our stakers can stake in complete anonymity. Read more on the [consensus page](/docs/learn/how-zano-works/consensus).
+Zarcanum is the world's first Proof-of-Stake scheme that enhances traditional PoS with untraceability and hidden amounts, revolutionizing blockchain consensus. Thanks to this innovative approach, our stakers can stake in complete anonymity. Read more on the [consensus page](/docs/learn/how-zano-works/consensus).
 
 ### How is the network secured?
 
@@ -115,7 +119,7 @@ Zano uses a hybrid consensus algorithm that alternates between Proof-of-Work (Po
 
 ### What's the plan for scaling?
 
-We'll continue to improve our dynamic blocksize (which our team pioneered initially with CryptoNote). Horizontal L1 scaling (sharding) is also on our radar as a long-term direction we're excited about.
+We'll continue to improve our dynamic blocksize (which our team pioneered initially with CryptoNote). Horizontal layer-1 scaling (sharding) is also on our radar as a long-term direction we're excited about.
 
 ---
 
@@ -207,7 +211,7 @@ No funds are locked; however, the foundation fund is an [auditable wallet](/docs
 
 ### How does Zano ensure decentralization if the devs hold some supply?
 
-Besides the fact that the foundation fund is a small share of the supply (see the [Emission page](/docs/learn/emission#the-premine-and-how-zano-will-be-funded)), Proof of Stake incentives ensure that all holders remain honest, if they were to harm the network, they would be attacking their own investment.
+Besides the fact that the foundation fund is a small share of the supply (see the [Emission page](/docs/learn/emission#the-premine-and-how-zano-will-be-funded)), Proof-of-Stake incentives ensure that all holders remain honest, if they were to harm the network, they would be attacking their own investment.
 
 ### Is there a public breakdown of the ZANO token distribution?
 
@@ -241,7 +245,7 @@ When bridging an asset to Zano using Confidential Layer, you receive its decentr
 
 ### How does Confidential Layer increase privacy? How is it different from mixers?
 
-It adds to bridged assets the same [technologies used by native Zano](#privacy-technologies).
+It adds to bridged assets the same [technologies used by native ZANO](#privacy-technologies).
 
 Unlike mixers, which obscure your transaction flow at a certain point (and you still need to watch your steps after), Confidential Layer cryptographically hides your balance, the data is never visible in the first place.
 
@@ -294,10 +298,6 @@ Zano is designed as a **decentralized, permissionless network**, which means it 
 ### When trying to send coins I get an error stating that the transaction is too large.
 
 The amount is composed of too many small inputs; split it up and send smaller amounts. See [Common Issues](/docs/use/troubleshooting/common-issues) for details.
-
-### What is a seed phrase?
-
-To access the wallet in the event of a loss, you need something called a mnemonic recovery phrase or seed. This group of words that you received while creating your wallet is designed to add an extra layer of security. With these phrases you can easily restore lost wallets if you don't have the passkey. See the [seed phrase guide](/docs/use/seed-phrase) for how to store it safely.
 
 ### Why does the desktop wallet take so long to start?
 

--- a/docs/learn/how-zano-works/consensus.md
+++ b/docs/learn/how-zano-works/consensus.md
@@ -10,7 +10,7 @@ Zano alternates between Proof-of-Work and Proof-of-Stake blocks. The PoW side ru
 
 To perform a classic 51% attack on Zano, an attacker needs the majority of the PoW hashrate **and** a large share of the staked coins at the same time. Other ratios are possible (for example, roughly 20% of hashrate against 90% of stake), but every combination requires attacking both resources at once, and buying up a significant share of the coins would drive the price up against the attacker. This makes an attack expensive enough that the network can keep a relatively low block reward while staying secure. The exact math is covered in the [research papers](/docs/learn/research).
 
-## Zarcanum: anonymous Proof of Stake
+## Zarcanum: anonymous Proof-of-Stake
 
 Zarcanum is the world's first Proof-of-Stake scheme with hidden amounts: you earn staking rewards without exposing how much you hold. Staking is open to everyone. There are no validator or master nodes, no minimum staking amounts, and no lock-up periods.
 

--- a/docs/learn/research.md
+++ b/docs/learn/research.md
@@ -59,6 +59,20 @@ Extension for the CLSAG (Concise Linkable Spontaneous Anonymous Group Signatures
 
 [https://eprint.iacr.org/2025/2335](https://eprint.iacr.org/2025/2335)
 
+## Additional research papers
+
+The following papers represent research toward a novel logarithmic-sized linkable ring signature scheme.
+
+- Lin2-Xor Lemma and Log-size Linkable Ring Signature (2020)  
+  In this paper we introduce a novel method for constructing an efficient linkable ring signature without a trusted setup which is logarithmic in the size of the signer anonymity set, its verification complexity is linear in the anonymity set size  
+  [https://github.com/hyle-team/docs/blob/master/zano/arch/Lin2-Xor_Lemma_and-Log-size_Linkable_Ring_Signature.pdf](https://github.com/hyle-team/docs/blob/master/zano/arch/Lin2-Xor_Lemma_and-Log-size_Linkable_Ring_Signature.pdf)
+- Hidden amounts scheme on the base of a ring signature for independent generators (2021)  
+  Draft of a hidden amounts scheme based on Lin2-Xor Linkable Ring Signature  
+  [https://github.com/hyle-team/docs/blob/master/zano/arch/Hidden%20amounts%20scheme%20v6%20Sokolov.pdf](https://github.com/hyle-team/docs/blob/master/zano/arch/Hidden%20amounts%20scheme%20v6%20Sokolov.pdf)
+- Log-size Linkable Ring Signature and Hidden Amounts integrated listing (2021)  
+  Unified pseudo-code listing for the Lin2-Xor Signature and Hidden Amounts schemes  
+  [https://github.com/hyle-team/docs/blob/master/zano/arch/Log-size%20Linkable%20Ring%20Signature%20and%20Hid-den%20Amounts%20integrated%20listing%20v3.pdf](https://github.com/hyle-team/docs/blob/master/zano/arch/Log-size%20Linkable%20Ring%20Signature%20and%20Hid-den%20Amounts%20integrated%20listing%20v3.pdf)
+
 ## Archive: drafts and legacy docs for history and context
 
 ### Zano Tokenization Platform (2022)
@@ -74,17 +88,3 @@ Note: this paper used one of the early approaches to implementing assets, where 
 Paper describes a practical way of implementing confidential assets (a.k.a. tokens) in Zano with unlimited decoy mixing capability and hidden amounts as an extension to the Ring Confidential Transactions scheme
 
 [https://raw.githubusercontent.com/hyle-team/docs/master/zano/tokens_maths_paper/Zano__confidential_assets_with_hidden_amounts_DRAFT.pdf](https://raw.githubusercontent.com/hyle-team/docs/master/zano/tokens_maths_paper/Zano__confidential_assets_with_hidden_amounts_DRAFT.pdf)
-
-## Additional research papers
-
-The following papers represent research toward a novel logarithmic-sized linkable ring signature scheme.
-
-- Lin2-Xor Lemma and Log-size Linkable Ring Signature (2020)  
-  In this paper we introduce a novel method for constructing an efficient linkable ring signature without a trusted setup which is logarithmic in the size of the signer anonymity set, its verification complexity is linear in the anonymity set size  
-  [https://github.com/hyle-team/docs/blob/master/zano/arch/Lin2-Xor_Lemma_and-Log-size_Linkable_Ring_Signature.pdf](https://github.com/hyle-team/docs/blob/master/zano/arch/Lin2-Xor_Lemma_and-Log-size_Linkable_Ring_Signature.pdf)
-- Hidden amounts scheme on the base of a ring signature for independent generators (2021)  
-  Draft of a hidden amounts scheme based on Lin2-Xor Linkable Ring Signature  
-  [https://github.com/hyle-team/docs/blob/master/zano/arch/Hidden%20amounts%20scheme%20v6%20Sokolov.pdf](https://github.com/hyle-team/docs/blob/master/zano/arch/Hidden%20amounts%20scheme%20v6%20Sokolov.pdf)
-- Log-size Linkable Ring Signature and Hidden Amounts integrated listing (2021)  
-  Unified pseudo-code listing for the Lin2-Xor Signature and Hidden Amounts schemes  
-  [https://github.com/hyle-team/docs/blob/master/zano/arch/Log-size%20Linkable%20Ring%20Signature%20and%20Hid-den%20Amounts%20integrated%20listing%20v3.pdf](https://github.com/hyle-team/docs/blob/master/zano/arch/Log-size%20Linkable%20Ring%20Signature%20and%20Hid-den%20Amounts%20integrated%20listing%20v3.pdf)

--- a/docs/learn/what-is-zano.md
+++ b/docs/learn/what-is-zano.md
@@ -20,7 +20,7 @@ Zano’s lead developer Andrey Sabelnikov wrote the original CryptoNote referenc
 
 Each technology has its own page under [How Zano Works](/docs/learn/how-zano-works). The papers behind them are in [Research & Audits](/docs/learn/research).
 
-**[Hybrid PoW/PoS Consensus](/docs/learn/how-zano-works/consensus)** alternates Proof of Work and Proof of Stake blocks. Attacking Zano requires both hashpower and stake, so no single vector is enough. The PoS side is **Zarcanum**, the world's first Proof of Stake scheme with hidden amounts: stakers secure the network without revealing their balances, with no validator nodes, minimum amounts, or lock-ups.
+**[Hybrid PoW/PoS Consensus](/docs/learn/how-zano-works/consensus)** alternates Proof-of-Work and Proof-of-Stake blocks. Attacking Zano requires both hashpower and stake, so no single vector is enough. The PoS side is **Zarcanum**, the world's first Proof-of-Stake scheme with hidden amounts: stakers secure the network without revealing their balances, with no validator nodes, minimum amounts, or lock-ups.
 
 **[Privacy technology](/docs/learn/how-zano-works/privacy-technology)**: d/v-CLSAG ring signatures, stealth addresses, and Bulletproofs+ hide the sender, receiver, and amount of every transaction.
 
@@ -30,9 +30,13 @@ Each technology has its own page under [How Zano Works](/docs/learn/how-zano-wor
 
 **[Auditable Wallets](/docs/learn/how-zano-works/auditable-wallets)** are opt-in transparent wallets for situations where a third party needs to verify balances. Enabling them on one wallet doesn’t affect privacy for anyone else on the network.
 
+### Key properties
+
+Those technologies add up to two properties that set Zano apart:
+
 **Fungibility**: every ZANO is identical. No coin has a "history" that can be traced, flagged, or blacklisted.
 
-**Uncensorable**: when transactions are invisible, they can’t be blocked, reversed, or selectively enforced.
+**Censorship resistance**: when transactions are invisible, they can’t be blocked, reversed, or selectively enforced.
 
 ### A stable, open network
 

--- a/docs/mine/overview.md
+++ b/docs/mine/overview.md
@@ -4,6 +4,6 @@ sidebar_position: 1
 
 # Mining Zano
 
-Zano uses ProgPoWZ for its mining algorithm, it's ASIC-resistant which means that it can only be mined using graphics cards.
+Zano uses ProgPowZ for its mining algorithm, it's ASIC-resistant which means that it can only be mined using graphics cards.
 
 The best way to support and further decentralize the network is to solo-mine it, we have prepared guides to help you get started.

--- a/docs/stake/_category_.json
+++ b/docs/stake/_category_.json
@@ -1,8 +1,0 @@
-{
-  "label": "Staking",
-  "position": 3,
-  "link": {
-    "type": "generated-index",
-    "description": "Learn how to stake Zano and earn rewards through Proof-of-Stake mining."
-  }
-} 

--- a/docs/stake/getting-started/estimating-pos-rewards.md
+++ b/docs/stake/getting-started/estimating-pos-rewards.md
@@ -30,7 +30,7 @@ $$
 Where $C$ is the total amount of coins participating in PoS mining, and $D_{PoS} \thinspace$ is the current PoS difficulty.
 ```
 
-As you may know, the Zano network emits an average of 1 coin each minute with a 50-50 spread between PoS and PoW. That makes it 720 potential PoS reward coins per day. So if you owned all the coins in PoS, that could be your total daily earnings. And if you divide C*C* by 720, you will get the number of coins you need to mine 1 Zano coin a day. Now, you can estimate the number of coins you will earn as:
+As you may know, the Zano network emits an average of 1 coin each minute with a 50-50 spread between PoS and PoW. That makes it 720 potential PoS reward coins per day. So if you owned all the coins in PoS, that could be your total daily earnings. And if you divide C*C* by 720, you will get the number of coins you need to mine 1 ZANO a day. Now, you can estimate the number of coins you will earn as:
 
 ```mdx-code-block
 $$

--- a/docs/stake/getting-started/proof-of-stake-mining.md
+++ b/docs/stake/getting-started/proof-of-stake-mining.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Staking Zano
+# Proof-of-Stake Guide
 
 Proof-of-stake mining or staking is typically implemented in such a way that a random coin owner obtains the right to sign a new block. Zano PoS implementation keeps miners in full anonymity and is as simple as a push of a button.
 

--- a/docs/use/dapps/index.md
+++ b/docs/use/dapps/index.md
@@ -6,7 +6,7 @@ Zano's dApps run in your browser and act on your own wallet: trading, messaging,
 Most dApps connect to your desktop wallet through [Zano Companion](/docs/use/companion), a browser extension that handles authentication and transaction signing. Install and pair it first; the individual guides assume it is set up.
 :::
 
-## The dApps
+## The dApps & bridges
 
 - **[Zano Trade](/docs/use/zano-trade)**: the decentralized exchange. Trade ZANO and Confidential Assets; orders match through a coordinator and settle on-chain as Ionic Swaps you co-sign.
 - **[Zano Matrix](/docs/use/zano-matrix-guide)**: private messaging built on Matrix, with your on-chain alias as your identity.

--- a/docs/use/dapps/wrapped-zano.md
+++ b/docs/use/dapps/wrapped-zano.md
@@ -28,7 +28,7 @@ It allows us access to the enormous existing infrastructure that exists around E
   />
 </div>
 
-The process of swapping ZANO to WZANO is referred to as “wrapping”. You can wrap ZANO from within any of the Zano mobile or desktop clients. Just go to the “Send” tab, enter the amount of ZANO you would like to receive and the Ethereum address to which you’d like the WZANO to be sent. You will be informed of how much Zano is required to cover the transaction fees before you finalize the transaction.
+The process of swapping ZANO to WZANO is referred to as “wrapping”. You can wrap ZANO from within any of the Zano mobile or desktop clients. Just go to the “Send” tab, enter the amount of ZANO you would like to receive and the Ethereum address to which you’d like the WZANO to be sent. You will be informed of how much ZANO is required to cover the transaction fees before you finalize the transaction.
 
 <figure style={{textAlign: 'center'}}>
   <img

--- a/docs/use/dapps/zano-matrix-guide.mdx
+++ b/docs/use/dapps/zano-matrix-guide.mdx
@@ -56,13 +56,13 @@ With an increase in compromised communication platforms like Telegram and WhatsA
 
 5. &#x20;After opening the app, make sure to change the server from `matrix.org` to `zano.org`.
 
-6. Use your Zano Alias as username and the password you just created to log in and get access to the Matrix server.
+6. Use your Zano alias as username and the password you just created to log in and get access to the Matrix server.
 
 7. Start messaging!
 
 Furthermore, it's possible to connect with people via the Zano Explorer.
 
-Simply click the Matrix connection icon to be forwarded to a one-on-one chat using the Zano Matrix Messenger!
+Simply click the Matrix connection icon to be forwarded to a one-on-one chat in Zano Matrix!
 
 ![zano-matrix-explorer](/img/use/zano-matrix/matrixexplorer.jpg)
 
@@ -80,7 +80,7 @@ No, your wallet is only used to claim your username and sign a message. This all
 
 Yes, Matrix is the respected, reviewed and popular protocol, trusted worldwide by companies and individuals who prioritize privacy.
 
-##### **What is the advantage of logging in with a Zano Alias over a traditional account?**
+##### **What is the advantage of logging in with a Zano alias over a traditional account?**
 
 You can reveal only your alias as a contact point or anonymously reach out to other alias owners. Aliases with Matrix connections can also be specified in the Zano block explorer.
 

--- a/docs/use/dapps/zano-trade.md
+++ b/docs/use/dapps/zano-trade.md
@@ -148,7 +148,7 @@ However if there's a demand for an app like this and users are willing to opt-in
 
 ### Which currencies can I trade?
 
-All [confidential assets](/docs/learn/frequently-asked-questions#what-are-confidential-assets-and-how-are-they-used-on-zano) issued or bridged over to Zano are tradeable.
+All [Confidential Assets](/docs/learn/frequently-asked-questions#what-are-confidential-assets-and-how-are-they-used-on-zano) issued or bridged over to Zano are tradeable.
 
 ### How long does it take before my transaction is processed?
 

--- a/docs/use/legacy/zarcanum-migration.md
+++ b/docs/use/legacy/zarcanum-migration.md
@@ -4,13 +4,13 @@ slug: /use/zarcanum-migration
 
 # Zarcanum Migration
 
-With the Zarcanum hardfork, Zano introduces an essential feature for all users: the Auto Migration process. This feature is designed to seamlessly transition your wallet to the post-Zarcanum era, ensuring that you can continue to stake and participate in the network without interruption.
+With the Zarcanum hard fork, Zano introduces an essential feature for all users: the Auto Migration process. This feature is designed to transition your wallet to the post-Zarcanum era, ensuring that you can continue to stake and participate in the network without interruption.
 
 ## What is Auto Migration?
 
 Auto Migration is an automated process within the Zano wallet that takes pre-Zarcanum outputs and consolidates them. Here's what it entails:
 
-**Collection**: The wallet automatically gathers all old outputs in your Zano wallet that were created before the Zarcanum hardfork.
+**Collection**: The wallet automatically gathers all old outputs in your Zano wallet that were created before the Zarcanum hard fork.
 
 **Consolidation**: These outputs are then consolidated into a few transactions. This step is crucial because it reduces the complexity and size of your wallet, making it more efficient.
 

--- a/docs/use/security-privacy/_category_.json
+++ b/docs/use/security-privacy/_category_.json
@@ -1,4 +1,9 @@
 {
   "label": "Security & Privacy",
-  "position": 3
+  "position": 3,
+  "link": {
+    "type": "generated-index",
+    "slug": "/use/security-privacy",
+    "description": "Keep your funds safe: seed phrases and passphrases, password types, download verification, and network-level privacy."
+  }
 }

--- a/docs/use/security-privacy/seed-phrase.md
+++ b/docs/use/security-privacy/seed-phrase.md
@@ -39,12 +39,12 @@ A **passphrase** is an additional layer of security that can be added to your se
 - Every time you restore your wallet, you will need to enter both the seed phrase and the passphrase.
 - If you forget the passphrase, you won’t be able to access your wallet, even with the seed phrase. Therefore, it’s essential to remember or securely store the passphrase.
 
-## Benefits
+## Passphrase benefits
 
 - **Enhanced Security:** The passphrase acts as a second required secret, making it significantly harder for someone to steal your funds.
 - **Privacy:** Even if someone sees your seed phrase, they cannot access your wallet without the passphrase.
 
-## Risks
+## Passphrase risks
 
 - **Loss of Passphrase:** If you forget or lose the passphrase, you will be permanently locked out of your wallet.
 - **Complexity:** Managing an additional passphrase can be cumbersome and may lead to user errors if not handled properly.

--- a/docs/use/security-privacy/socks5-proxy-relay.md
+++ b/docs/use/security-privacy/socks5-proxy-relay.md
@@ -13,7 +13,7 @@ You (wallet)                           The network sees only the proxy IP
      |
      |--- sync blockchain -------> your local daemon
      |
-     |--- send tx/PoS block ----> SOCKS5 proxy (Tor or any mixin Network) ----> remote node ----> network
+     |--- send tx/PoS block ----> SOCKS5 proxy (Tor or any anonymizing network) ----> remote node ----> network
 ```
 
 ## Prerequisites

--- a/docs/use/wallets/cli/using-zano-cli-wallet-ubuntu.md
+++ b/docs/use/wallets/cli/using-zano-cli-wallet-ubuntu.md
@@ -41,7 +41,7 @@ To see your balance:
 balance
 ```
 
-To see balances for all assets (ZANO, confidential assets, etc.):
+To see balances for all assets (ZANO, Confidential Assets, etc.):
 
 ```
 balance raw
@@ -79,7 +79,7 @@ An optional **payment_id** can be appended at the end for services that require 
 
 ### Sending assets
 
-To send a confidential asset other than ZANO, prefix the address with the asset ID:
+To send a Confidential Asset other than ZANO, prefix the address with the asset ID:
 
 ```
 transfer 15 <asset_id>:<address> <amount>
@@ -274,7 +274,7 @@ These commands are used inside the wallet console after opening.
 | `sweep_below` | `<mixin> <address> <amount_limit> [payment_id]`: consolidate small outputs |
 | `sweep_bare_outs` | Transfer all bare (non-ZC) outputs to self |
 | `set_log` | `<level>`: change log verbosity (0-4) |
-| `deploy_new_asset` | `<json_file>`: deploy a new confidential asset |
+| `deploy_new_asset` | `<json_file>`: deploy a new Confidential Asset |
 | `emit_asset` | `<asset_id> <amount>`: mint more of an asset you own |
 | `burn_asset` | `<asset_id> <amount>`: burn asset tokens |
 | `check_all_tx_keys` | Verify one-time secret keys for all sent transactions |

--- a/docs/use/wallets/gui-wallet.md
+++ b/docs/use/wallets/gui-wallet.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Create and Manage Wallets (GUI)
 
-Zano Wallet lets you manage multiple ZANO wallets, which can be easily created, restored, and removed from the app. The core of each wallet is a seed phrase, a sequence of 24–26 words (26 for wallets created in current versions) that can be used to recover your wallet's private and public keys. A unique sequence is generated every time you create a new wallet within the app. **It's important to always keep it safe and accessible.**
+Zano Wallet lets you manage multiple Zano wallets, which can be easily created, restored, and removed from the app. The core of each wallet is a seed phrase, a sequence of 24–26 words (26 for wallets created in current versions) that can be used to recover your wallet's private and public keys. A unique sequence is generated every time you create a new wallet within the app. **It's important to always keep it safe and accessible.**
 
 For your convenience, it's not necessary to use a seed phrase to manage your wallet. In the official Zano Wallet apps, when you create a wallet, a wallet file is generated as well. This file is secured with an additional password, granting access to wallet features and the seed phrase. It can be copied to another device and used with another app.
 

--- a/docs/use/wallets/overview.md
+++ b/docs/use/wallets/overview.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Zano Apps & Wallets
+# Zano Wallets
 
 ### Desktop Apps
 
@@ -18,7 +18,7 @@ You can use Zano Companion on Chrome (Connects to your desktop wallet)
 
 ### Download Links
 
-Available on the [Zano Website](https://zano.org/wallets) and [Github](https://github.com/hyle-team/zano/releases)
+Available on the [Zano Website](https://zano.org/wallets) and [GitHub](https://github.com/hyle-team/zano/releases)
 
 ### Third-Party Wallets
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -53,6 +53,8 @@ const config = {
           { from: "/docs/learn/password-specs", to: "/docs/build/password-specs" },
           // pre-restructure slug fix debt: old .md-suffixed URL
           { from: "/docs/use/zano-passwords.md", to: "/docs/use/zano-passwords" },
+          // deeplinks page lives in the Build tab but had a /use/ slug
+          { from: "/docs/use/deeplinks", to: "/docs/build/deeplinks" },
         ],
       },
     ],

--- a/src/pages/StartPage/StartPage.jsx
+++ b/src/pages/StartPage/StartPage.jsx
@@ -58,7 +58,7 @@ const sections = [
     links: [
       { label: "Getting Started", to: "/docs/use/overview" },
       { label: "Wallets", to: "/docs/use/wallets/overview" },
-      { label: "Security & Privacy", to: "/docs/use/seed-phrase" },
+      { label: "Security & Privacy", to: "/docs/use/security-privacy" },
       { label: "dApps & Bridges", to: "/docs/use/dapps/" },
       { label: "Troubleshooting", to: "/docs/use/troubleshooting/common-issues" },
     ],


### PR DESCRIPTION
Follow-up to the facelift, driven by community feedback that the What is Zano page listed Fungibility and Uncensorable under "Key technologies". Fixed that (new Key properties section, Uncensorable renamed Censorship resistance for parallel wording) and swept the whole tree for the same classes of problem. ~35 fixes across 35 files:

**Headings that didn't match their content**: stray copy-pasted heading on the integrated-addresses page; duplicate "Daemon flags" heading over the wallet's flags (plus a wrong flag description); "Exchange Listing Guidelines" renamed to Exchange Integration Guidelines to match what the section actually covers; FAQ's seed-phrase definition moved from Troubleshooting to Beginner Questions; seed-phrase page's Benefits/Risks scoped to the passphrase they describe; dApps index heading now includes bridges.

**Product naming**: Zano Messenger → Zano Matrix, Bridgeless → Confidential Layer (with Bridgeless credited as the L1), Zano Stats → ZanoStats, "Zano trade API" casing, a stray "Zano Extension", Zano Alias → Zano alias.

**Terminology**: Proof-of-Work / Proof-of-Stake hyphenation unified; ZANO (coin) vs Zano (project) corrections; Confidential Assets capitalization; hardfork → hard fork; the SOCKS5 diagram's "mixin Network" → "anonymizing network"; GitHub/YouTube brand casing in the footer and docs.

**Structural**: the "Сonfirm transaction" sidebar label started with a Cyrillic С (U+0421) — now Latin; the Deeplinks page (Build tab) had a /use/ URL — slug moved to /build/ with a client redirect; Security & Privacy now has a category index page and the landing card points there; dead root-level stake _category_.json removed; two bare "Overview" page titles disambiguated.

Auto-generated RPC pages were left alone; their two defects (alias_lookup lead sentence, getblocktemplate ProgPoWZ spelling) belong in the doc generator upstream.

Build green with onBrokenLinks: throw; new and moved URLs verified in the build output.