### PR TITLE
Fix docs build-machine guard: key on branch, not build_prefix

### DIFF
--- a/scripts/API-VERSIONING.md
+++ b/scripts/API-VERSIONING.md
@@ -42,7 +42,12 @@ The release build script's old doc section (rm + `--generate-rpc-autodoc` into
 - invariants are checked before committing; a no-change regen exits cleanly
   instead of failing on an empty commit
 - requires python3 on the build machine (stdlib only)
-- builds with `$build_prefix` set (custom builds) skip the docs update entirely
+- only release-line builds update docs: the script skips unless `BRANCH_NAME`
+  is release/master/main (this Jenkins setup sets `build_prefix=$BRANCH_NAME`
+  on every build, so build_prefix cannot be used to tell builds apart)
+- mainnet vs testnet is detected from the binary's own version string, and no
+  variables need exporting from the calling script
+- `DRY_RUN=1` generates and validates without touching git
 
 ## Invariants `check` enforces (also safe in CI)
 

--- a/scripts/build-machine-docs.sh
+++ b/scripts/build-machine-docs.sh
@@ -1,48 +1,83 @@
 #!/bin/bash
-# Drop-in "Writing documentation..." section for the Zano release build script.
-# Replaces the old rm/--generate-rpc-autodoc/commit block, which no longer works:
-# the RPC reference moved to api-reference/ and is versioned (see API-VERSIONING.md).
+# Documentation step for the Zano release build script.
+# Replaces the old rm/--generate-rpc-autodoc/commit block: the RPC reference
+# moved to api-reference/ and is versioned (see API-VERSIONING.md).
 #
-# Expects (already set by the surrounding build script):
-#   $daemon_path   built zanod
-#   $wallet_path   built simplewallet
-#   $version_str   e.g. "v2.2.1.502[76a791c]" (from zanod --version)
-#   $testnet       "true" for testnet builds
+# Call it from the build script after the binaries are built:
+#     bash /home/user/zano-docs/scripts/build-machine-docs.sh
 #
+# Everything it needs it derives itself, so no variables have to be exported:
+#   * binaries      $daemon_path / $wallet_path if set, else the standard
+#                   build output path (override with BUILD_SRC)
+#   * version+net   read from the binary itself (`--version`), which is the
+#                   source of truth: "Zano v2.2.1.505[...]" -> mainnet,
+#                   "Zano_testnet v..." -> testnet snapshot
+#   * BRANCH_NAME   docs update only for release-line builds
+#
+# Env knobs: DOCS_DIR, BUILD_SRC, DRY_RUN=1 (generate + validate, no git writes).
 # Requires: python3 (stdlib only).
 
 set -e
 
-# guard: docs update only for standard release builds — custom builds set
-# $build_prefix (the surrounding script prefixes archive names with it)
-if [ -n "$build_prefix" ]; then
-  echo "build_prefix='$build_prefix' set — skipping docs update (custom build)"
-  exit 0
+DOCS_DIR="${DOCS_DIR:-/home/user/zano-docs}"
+BUILD_SRC="${BUILD_SRC:-/home/user/zano-custom-branch/build/release/src}"
+ZANOD="${daemon_path:-$BUILD_SRC/zanod}"
+SIMPLEWALLET="${wallet_path:-$BUILD_SRC/simplewallet}"
+
+# Only release-line builds feed the published reference. Feature/develop builds
+# are skipped: the Mainnet version tracks releases, and develop can diverge from
+# the release lineage. An unset BRANCH_NAME (manual run) is allowed.
+case "${BRANCH_NAME-release}" in
+  release|master|main|"") ;;
+  *)
+    echo "BRANCH_NAME='$BRANCH_NAME' is not a release branch — skipping docs update"
+    exit 0
+    ;;
+esac
+
+if [ ! -x "$ZANOD" ] || [ ! -x "$SIMPLEWALLET" ]; then
+  echo "ERROR: binaries not found ($ZANOD / $SIMPLEWALLET)" >&2
+  exit 1
 fi
 
-echo "Writing documentation..."
+# the binary announces both its version and its network
+version_line=$("$ZANOD" --version | awk '/^Zano/ { print; exit }')
+version_core=$(echo "$version_line" | awk '{ print $2 }' | sed -e 's/^v//' -e 's/\[.*$//')
+if [ -z "$version_core" ]; then
+  echo "ERROR: could not parse version from: $version_line" >&2
+  exit 1
+fi
+case "$version_line" in
+  Zano_testnet*) network=testnet ;;
+  *)             network=mainnet ;;
+esac
+echo "Writing documentation... ($network, $version_core)"
 
-cd /home/user/zano-docs
-git reset --hard
-git pull -r
+cd "$DOCS_DIR"
+if [ "${DRY_RUN:-}" != "1" ]; then
+  git reset --hard
+  git pull -r
+fi
 
-# picker label: "v2.2.1.502[abc1234]" -> "2.2.1.502"
-version_core=$(echo "$version_str" | sed -e 's/^v//' -e 's/\[.*$//')
-
-if [ "$testnet" == true ]; then
-  # testnet builds refresh the Testnet snapshot; mainnet reference is untouched
+if [ "$network" = testnet ]; then
   python3 scripts/api_version.py testnet \
-    --zanod "$daemon_path" --simplewallet "$wallet_path" \
+    --zanod "$ZANOD" --simplewallet "$SIMPLEWALLET" \
     --label "Testnet (${version_core})"
 else
-  # mainnet builds roll the current version forward; when the release line
-  # changes (e.g. 2.2.1 -> 2.3.0) the old release is auto-archived first
+  # rolls the current version forward; crossing a release line
+  # (e.g. 2.2.1 -> 2.3.0) auto-archives the outgoing release first
   python3 scripts/api_version.py rollover \
-    --zanod "$daemon_path" --simplewallet "$wallet_path" \
+    --zanod "$ZANOD" --simplewallet "$SIMPLEWALLET" \
     --label "Mainnet (${version_core})"
 fi
 
 python3 scripts/api_version.py check
+
+if [ "${DRY_RUN:-}" = "1" ]; then
+  echo "DRY_RUN=1 — generated and validated, no git writes"
+  git --no-pager diff --stat
+  exit 0
+fi
 
 git add -A
 if git diff --cached --quiet; then


### PR DESCRIPTION
The first release-branch run of the new docs step skipped everything:

    + bash /home/user/zano-docs/scripts/build-machine-docs.sh
    build_prefix='release' set — skipping docs update (custom build)

The Jenkins job injects `build_prefix=$BRANCH_NAME`, so build_prefix is set on every build including releases — it cannot distinguish build types. My guard assumed otherwise, so no build would ever update the docs.

Changes:
- Guard now keys on `BRANCH_NAME` (release/master/main proceed; develop and feature branches skip). This also implements the intended rule that the Mainnet reference tracks releases rather than develop, which can diverge from the release lineage.
- Version and network are now read from the binary's own `--version` output rather than from shell variables the calling script does not export (`Zano v...` = mainnet, `Zano_testnet v...` = testnet snapshot). Binary paths fall back to the standard build output when not provided. This removes the need for the caller to export anything, which the build script currently does not do.
- `DRY_RUN=1` generates and validates without any git writes.

Tested against real binaries: develop branch skips; release branch proceeds; a testnet binary is detected and routed to the testnet snapshot; invariants check passes in every case.

No further change is needed on the build machine: the release script already pulls this repo before invoking the script, so the next run picks this up. That run will roll the Mainnet version from 2.2.1.502 to the current release build (2.2.1.505).